### PR TITLE
Fixed arrow keys not working when running under Emacs term.el

### DIFF
--- a/bestline.c
+++ b/bestline.c
@@ -2819,6 +2819,10 @@ static ssize_t bestlineEdit(int stdin_fd, int stdout_fd, const char *prompt,
             case 'O':
                 if (nread < 3) break;
                 switch (seq[2]) {
+                Case('A', bestlineEditUp(&l));
+                Case('B', bestlineEditDown(&l));
+                Case('C', bestlineEditRight(&l));
+                Case('D', bestlineEditLeft(&l));
                 Case('H', bestlineEditHome(&l));
                 Case('F', bestlineEditEnd(&l));
                 default:


### PR DESCRIPTION
Hey there,

Emacs seems to send 0A - 0D instead of [A - `[Dwhen pressing arrow keys, so I added cases for these sequences as well.

Have a nice day,
Ben