### PR TITLE
Fixed warnings/errors when compiling on ARM

### DIFF
--- a/bestline.c
+++ b/bestline.c
@@ -233,7 +233,7 @@ static const char *const kUnsupported[] = {"dumb","cons25","emacs"};
 static int gotint;
 static int gotcont;
 static int gotwinch;
-static char rawmode;
+static signed char rawmode;
 static char maskmode;
 static char ispaused;
 static char iscapital;


### PR DESCRIPTION
Hey there,

I ran into an issue when compiling bestline on ARM with -Werror due to chars being unsigned by default there which led to errors when comparing against -1 later on. 

Oh and thank you for adding parenthesis matching, great feature!

Have a nice day,
Ben