### PR TITLE
Add support for initial text

### DIFF
--- a/bestline.h
+++ b/bestline.h
@@ -18,7 +18,9 @@ void bestlineAddCompletion(bestlineCompletions *, const char *);
 void bestlineSetXlatCallback(bestlineXlatCallback *);
 
 char *bestline(const char *);
+char *bestlineInit(const char *, const char *);
 char *bestlineRaw(const char *, int, int);
+char *bestlineRawInit(const char *, const char *, int, int);
 char *bestlineWithHistory(const char *, const char *);
 int bestlineHistoryAdd(const char *);
 int bestlineHistorySave(const char *);


### PR DESCRIPTION
This is like bash `read -ei "initial text"`. It is useful if you want to prompt the user to edit some text without having to rewrite it, or awkwardly ask them to get it from history. Same as `bash -ei`, it only works if the terminal is supported.