### PR TITLE
Continue to fix typo of Chinese, Japanese, Korean.

### DIFF
--- a/bestline.c
+++ b/bestline.c
@@ -47,7 +47,7 @@
 │   - Remove heavyweight dependencies like printf/sprintf                      │
 │   - Remove ISIG→^C→EAGAIN hack and use ephemeral handlers                    │
 │   - Support running on Windows in MinTTY or CMD.EXE on Win10+                │
-│   - Support diacratics, русский, Ελληνικά, 中国人, 日本語, 한국인            │
+│   - Support diacratics, русский, Ελληνικά, 漢字, 仮名, 한글                  │
 │                                                                              │
 │ SHORTCUTS                                                                    │
 │                                                                              │


### PR DESCRIPTION
I think the `bestline.c` should also apply the changes from https://github.com/jart/bestline/pull/17.

Kenji Mouri