### PR TITLE
Make IsBalanced() optional

### DIFF
--- a/bestline.c
+++ b/bestline.c
@@ -239,6 +239,7 @@ static int gotcont;
 static int gotwinch;
 static signed char rawmode;
 static char maskmode;
+static char balancemode;
 static char ispaused;
 static char iscapital;
 static unsigned historylen;
@@ -3129,7 +3130,7 @@ static ssize_t bestlineEdit(int stdin_fd, int stdout_fd, const char *prompt,
             }
             break;
         case '\r':
-            if (IsBalanced(&l)) {
+            if (!balancemode || IsBalanced(&l)) {
                 l.final = 1;
                 free(history[--historylen]);
                 history[historylen] = 0;
@@ -3606,4 +3607,14 @@ void bestlineMaskModeEnable(void) {
  */
 void bestlineMaskModeDisable(void) {
     maskmode = 0;
+}
+
+/**
+ * Enables or disables "balance mode".
+ *
+ * When it is enabled, bestline() will block until parentheses are
+ * balanced. This is useful for code but not for free text.
+ */
+void bestlineBalanceMode(char mode) {
+    balancemode = mode;
 }

--- a/bestline.h
+++ b/bestline.h
@@ -30,6 +30,7 @@ void bestlineHistoryFree(void);
 void bestlineClearScreen(int);
 void bestlineMaskModeEnable(void);
 void bestlineMaskModeDisable(void);
+void bestlineBalanceMode(char);
 void bestlineDisableRawMode(void);
 void bestlineFree(void *);
 

--- a/example.c
+++ b/example.c
@@ -68,6 +68,10 @@ int main(int argc, char **argv) {
             bestlineMaskModeEnable();
         } else if (!strncmp(line, "/unmask", 7)) {
             bestlineMaskModeDisable();
+        } else if (!strncmp(line, "/balance", 8)) {
+            bestlineBalanceMode(1);
+        } else if (!strncmp(line, "/unbalance", 10)) {
+            bestlineBalanceMode(0);
         } else if (line[0] == '/') {
             fputs("Unreconized command: ", stdout);
             fputs(line, stdout);


### PR DESCRIPTION
Since e7489f6, bestline() never returns when the input is something like `a b :)`. This is probably good for REPL use cases, but less nice for applications like [gplaces](https://github.com/dimkr/gplaces) where the user enters free text and not code.

(IsBalanced() underflows against `a b :)` and allows input like `a )(`, but these are separate issues, and my use case doesn't need IsBalanced() at all)