### PR TITLE
Fix underflow in IsBalanced()

### DIFF
--- a/bestline.c
+++ b/bestline.c
@@ -3022,9 +3022,9 @@ static char IsBalanced(struct bestlineState *l) {
     unsigned i, d;
     for (d = i = 0; i < l->len; ++i) {
         if (l->buf[i] == '(') ++d;
-        if (l->buf[i] == ')') --d;
+        else if (d > 0 && l->buf[i] == ')') --d;
     }
-    return d <= 0;
+    return d == 0;
 }
 
 /**


### PR DESCRIPTION
That `d <= 0` indicates that this function is supposed to return 0 and not 1 when the input is something like `a )`. However, `d` is unsigned, so `unsigned d = 0 - 1 = 0xffffffff` and IsBalanced() returns 1.