### PR TITLE
Make bestline work in rc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,11 @@ bestline.o: bestline.c bestline.h Makefile
 example.o: example.c bestline.h Makefile
 multi.o: multi.c bestline.h Makefile
 
+libbestline.so: bestline.c
+	$(CC) $(LDFLAGS) -fPIC -shared bestline.c -o $@
+
 clean:
-	rm -f bestline_example bestline.o example.o bestline_example.com bestline_example.com.dbg multi.o bestline_multi
+	rm -f bestline_example bestline.o example.o bestline_example.com bestline_example.com.dbg multi.o bestline_multi libbestline.so
 
 ################################################################################
 # compile on linux the demo as a binary that runs on seven operating systems

--- a/bestline.c
+++ b/bestline.c
@@ -2010,7 +2010,7 @@ static ssize_t bestlineCompleteLine(struct bestlineState *ls, char *seq, int siz
     struct bestlineState saved;
     nread = 0;
     memset(&lc, 0, sizeof(lc));
-    completionCallback(ls->buf, &lc);
+    completionCallback(ls->buf, ls->pos, &lc);
     if (!lc.len) {
         bestlineBeep();
     } else {

--- a/bestline.c
+++ b/bestline.c
@@ -2007,7 +2007,7 @@ static ssize_t bestlineCompleteLine(struct bestlineState *ls, char *seq, int siz
     ssize_t nread;
     size_t i, n, stop;
     bestlineCompletions lc;
-    struct bestlineState saved;
+    struct bestlineState original, saved;
     nread = 0;
     memset(&lc, 0, sizeof(lc));
     completionCallback(ls->buf, ls->pos, &lc);
@@ -2016,11 +2016,13 @@ static ssize_t bestlineCompleteLine(struct bestlineState *ls, char *seq, int siz
     } else {
         i = 0;
         stop = 0;
+        original = *ls;
         while (!stop) {
             /* Show completion or original buffer */
             if (i < lc.len) {
                 saved = *ls;
-                ls->len = ls->pos = strlen(lc.cvec[i]);
+                ls->len = strlen(lc.cvec[i]);
+                ls->pos = original.pos + ls->len - original.len;
                 ls->buf = lc.cvec[i];
                 bestlineRefreshLine(ls);
                 ls->len = saved.len;
@@ -2045,7 +2047,8 @@ static ssize_t bestlineCompleteLine(struct bestlineState *ls, char *seq, int siz
                     n = strlen(lc.cvec[i]);
                     if (bestlineGrow(ls, n + 1)) {
                         memcpy(ls->buf, lc.cvec[i], n + 1);
-                        ls->len = ls->pos = n;
+                        ls->len = n;
+                        ls->pos = original.pos + n - original.len;
                     }
                 }
                 stop = 1;

--- a/bestline.h
+++ b/bestline.h
@@ -8,7 +8,8 @@ typedef struct bestlineCompletions {
     char **cvec;
 } bestlineCompletions;
 
-typedef void(bestlineCompletionCallback)(const char *, bestlineCompletions *);
+typedef void(bestlineCompletionCallback)(const char *, int,
+                                         bestlineCompletions *);
 typedef char *(bestlineHintsCallback)(const char *, const char **, const char **);
 typedef void(bestlineFreeHintsCallback)(void *);
 typedef unsigned(bestlineXlatCallback)(unsigned);

--- a/example.c
+++ b/example.c
@@ -21,7 +21,8 @@ int main() {
 }
 #endif
 
-void completion(const char *buf, bestlineCompletions *lc) {
+void completion(const char *buf, int pos, bestlineCompletions *lc) {
+    (void) pos;
     if (buf[0] == 'h') {
         bestlineAddCompletion(lc,"hello");
         bestlineAddCompletion(lc,"hello there");
@@ -55,7 +56,7 @@ int main(int argc, char **argv) {
      *
      * The typed string is returned as a malloc() allocated string by
      * bestline, so the user needs to free() it. */
-    
+
     while((line = bestline("hello> ")) != NULL) {
         /* Do something with the string. */
         if (line[0] != '\0' && line[0] != '/') {


### PR DESCRIPTION
I have created a pull request to [rakitzis/rc](https://github.com/rakitzis/rc) to integrate bestline: [Support bestline for line editing #100](https://github.com/rakitzis/rc/pull/100).

Unfortunately, _bestline_ isn't ideal to be used in rc as it is now:

To be useful in a shell, it's necessary to pass the cursor position when calling the `complete` function because the user might want to complete any word (token) in the current command line. I'm aware that this is a breaking change. But it might make bestline more suitable for other projects, too.

This pull request also adds a new `libbestline.so` target to the `Makefile` because the `rc` maintainers prefer linking against a shared library instead of copying the current state of a line editing library (at least they did in the past: https://github.com/rakitzis/rc/pull/5#issuecomment-304394764).